### PR TITLE
fix: make status bar dark in dark mode on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "expo-file-system": "^10.0.0",
     "expo-image-picker": "^10.0.0",
     "expo-sharing": "^9.0.0",
+    "expo-status-bar": "^1.0.3",
     "prettier": "^2.2.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
     "react-scripts": "^4.0.1",
@@ -71,7 +72,8 @@
   "peerDependencies": {
     "expo-file-system": "*",
     "expo-image-picker": "*",
-    "expo-sharing": "*"
+    "expo-sharing": "*",
+    "expo-status-bar": "*"
   },
   "peerDependenciesMeta": {
     "expo-file-system": {
@@ -81,6 +83,9 @@
       "optional": true
     },
     "expo-sharing": {
+      "optional": true
+    },
+    "expo-status-bar": {
       "optional": true
     }
   },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"; // for expo
 import { FC, useState, useEffect } from "react";
 import { Dimensions } from "react-native";
+import { StatusBar } from "expo-status-bar";
 import { Provider } from "jotai";
 
 import Canvas from "./Canvas";
@@ -23,10 +24,15 @@ export const App: FC = () => {
       Dimensions.removeEventListener("change", onChange);
     };
   }, []);
+
   return (
-    <Provider>
-      <Canvas width={dimensions.width} height={dimensions.height} />
-    </Provider>
+    <>
+      <Provider>
+        <Canvas width={dimensions.width} height={dimensions.height} />
+      </Provider>
+      {/* eslint-disable react/style-prop-object */}
+      <StatusBar style="dark" />
+    </>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,6 +6103,11 @@ expo-sqlite@~8.5.0:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.3.tgz#62b4d6145680abd43ba6ecfa465f835e88bf6263"
+  integrity sha512-/Orgla1nkIrfswNHbuAOTbPVq0g3+GrhoQVk7MRafY2dwrFLgXhaPExS+eN2hpmzqPv2LG5cqAZDCQUAjmZYBQ==
+
 expo@^40.0.1:
   version "40.0.1"
   resolved "https://registry.yarnpkg.com/expo/-/expo-40.0.1.tgz#20ae9f9c787ba1662037094dfd6982380f2c0288"


### PR DESCRIPTION
The default status bar behavior in React Native on iOS is to be the opposite of the color scheme - light when the color scheme is dark, and dark when the color scheme is light. This PR enforces a dark status bar because this app doesn't yet support dark mode.

Note: I'm not familiar with how the dependencies are set up, so I copied the existing convention for expo-* packages when installing expo-status-bar.

## Before

https://user-images.githubusercontent.com/90494/108941411-eb560b00-7609-11eb-92c7-c0a9aaaf484d.mov

## After

https://user-images.githubusercontent.com/90494/108941452-ff9a0800-7609-11eb-9a40-b80ed4d5cd50.mov