### PR TITLE
Introduce XState for managing state in the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@xstate/react": "^1.3.1",
     "jotai": "^0.15.0",
     "perfect-freehand": "^0.2.3",
     "react": "^17.0.1",
@@ -46,7 +47,9 @@
     "react-native-svg": "^12.1.0",
     "react-native-web": "^0.14.10",
     "svg-path-bbox": "^0.2.0",
-    "svgpath": "^2.3.1"
+    "svgpath": "^2.3.1",
+    "uuid": "^8.3.2",
+    "xstate": "^4.16.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.9",
@@ -58,6 +61,8 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-native": "^0.63.46",
     "@types/svg-path-bbox": "^0.2.0",
+    "@types/uuid": "^8.3.0",
+    "@xstate/inspect": "^0.4.1",
     "browser-fs-access": "^0.13.1",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@xstate/react": "^1.3.1",
+    "@xstate/react": "^1.3.2",
     "jotai": "^0.15.0",
     "perfect-freehand": "^0.2.3",
     "react": "^17.0.1",
@@ -49,7 +49,7 @@
     "svg-path-bbox": "^0.2.0",
     "svgpath": "^2.3.1",
     "uuid": "^8.3.2",
-    "xstate": "^4.16.2"
+    "xstate": "4.18.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.9",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,11 +5,10 @@ import { FC, useEffect, useState } from "react";
 import { Dimensions } from "react-native";
 import Canvas from "./Canvas";
 
-process.env.NODE_ENV === "development" &&
-  inspect({
-    url: "https://statecharts.io/inspect",
-    iframe: false,
-  });
+inspect({
+  url: "https://statecharts.io/inspect",
+  iframe: false,
+});
 
 export const App: FC = () => {
   const [dimensions, setDimensions] = useState<{

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,9 +1,15 @@
-import * as React from "react"; // for expo
-import { FC, useState, useEffect } from "react";
-import { Dimensions } from "react-native";
+import { inspect } from "@xstate/inspect";
 import { StatusBar } from "expo-status-bar";
-
+import * as React from "react"; // for expo
+import { FC, useEffect, useState } from "react";
+import { Dimensions } from "react-native";
 import Canvas from "./Canvas";
+
+process.env.NODE_ENV === "development" &&
+  inspect({
+    url: "https://statecharts.io/inspect",
+    iframe: false,
+  });
 
 export const App: FC = () => {
   const [dimensions, setDimensions] = useState<{

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -38,7 +38,7 @@ export const Canvas: FC<Props> = ({
 
   useEffect(() => {
     service.send({ type: "SET_DIMENSIONS", width, height });
-  }, [width, height]);
+  }, [width, height, service]);
 
   return (
     <Svg viewBox={`${offset.x} ${offset.y} ${width / zoom} ${height / zoom}`}>

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,19 +1,14 @@
 import * as React from "react"; // for expo
 import { FC, memo } from "react";
 import { Rect } from "react-native-svg";
-import { useAtom } from "jotai";
-
-import { modeAtom } from "../atoms/canvas";
-import { setColorAtom } from "../atoms/colorPicker";
-import { hackTouchableNode } from "../utils/touchHandlerHack";
 import openColors from "../utils/open-color.json";
+import { hackTouchableNode } from "../utils/touchHandlerHack";
 
-export const ColorPicker: FC = () => {
-  const [mode] = useAtom(modeAtom);
-  const [, setColor] = useAtom(setColorAtom);
-  if (mode !== "color") {
-    return null;
-  }
+type Props = {
+  setColor?: any;
+};
+
+export const ColorPicker: FC<Props> = ({ setColor }) => {
   return (
     <>
       <Rect

--- a/src/components/Dots.tsx
+++ b/src/components/Dots.tsx
@@ -1,12 +1,12 @@
 import * as React from "react"; // for expo
 import { FC, memo } from "react";
 import { Circle } from "react-native-svg";
-import { useAtom } from "jotai";
 
-import { dotsAtom } from "../atoms/dots";
+type Props = {
+  dots: [];
+};
 
-export const Dots: FC = () => {
-  const [dots] = useAtom(dotsAtom);
+export const Dots: FC<Props> = ({ dots }) => {
   return (
     <>
       {dots.map((dot, index) => (

--- a/src/components/Shape.tsx
+++ b/src/components/Shape.tsx
@@ -1,11 +1,9 @@
 import { useService } from "@xstate/react";
-import { useAtom } from "jotai";
 import * as React from "react"; // for expo
 import { FC, memo } from "react";
 import { Platform } from "react-native";
 import { G, Image, Path, Rect } from "react-native-svg";
-import { IsPointInShape, setPressingShapeAtom } from "../atoms/drag";
-import { ShapeAtom, TShapeImage, TShapePath } from "../atoms/shapes";
+import { IsPointInShape } from "../atoms/drag";
 import { hackTouchableNode } from "../utils/touchHandlerHack";
 
 const ShapePath: React.FC<{
@@ -14,7 +12,7 @@ const ShapePath: React.FC<{
   const [state, send] = useService<any, any, any>(service);
   const ref = React.useRef(null);
   const selected = state.matches("selected");
-  const { x, y, scale, path, color, id } = state.context;
+  const { x, y, scale, path, color } = state.context;
 
   React.useEffect(() => {
     const instance: any = ref.current;

--- a/src/components/Shapes.tsx
+++ b/src/components/Shapes.tsx
@@ -1,17 +1,16 @@
 import * as React from "react"; // for expo
 import { FC, memo } from "react";
-import { useAtom } from "jotai";
-
-import { allShapesAtom, selectedAtom } from "../atoms/shapes";
 import Shape from "./Shape";
 
-export const Shapes: FC = () => {
-  const [shapeAtomList] = useAtom(allShapesAtom);
-  useAtom(selectedAtom); // to initialize the derived atom (Hmmm)
+type Props = {
+  shapes: any;
+};
+
+export const Shapes: FC<Props> = ({ shapes }) => {
   return (
     <>
-      {shapeAtomList.map((shapeAtom) => (
-        <Shape key={`${shapeAtom}`} shapeAtom={shapeAtom} />
+      {Object.keys(shapes).map((id: any) => (
+        <Shape key={id} service={shapes[id].ref} type={shapes[id].type} />
       ))}
     </>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,54 +1,101 @@
+import { useSelector } from "@xstate/react";
 import * as React from "react"; // for expo
-import { FC, ReactElement, memo } from "react";
+import { FC, memo } from "react";
 import { G, Rect } from "react-native-svg";
-import { useAtom } from "jotai";
-
-import { toolbarAtom } from "../atoms/toolbar";
 import ColorPicker from "../components/ColorPicker";
-import { hackTouchableNode } from "../utils/touchHandlerHack";
-import PenIcon from "../icons/Pen";
+import BiggerIcon from "../icons/Bigger";
+import DeleteIcon from "../icons/Delete";
 import HandIcon from "../icons/Hand";
+import ImageIcon from "../icons/Image";
 import MoveIcon from "../icons/Move";
+import PaletteIcon from "../icons/Palette";
+import PenIcon from "../icons/Pen";
+import SaveIcon from "../icons/Save";
+import SmallerIcon from "../icons/Smaller";
 import ZoomInIcon from "../icons/ZoomIn";
 import ZoomOutIcon from "../icons/ZoomOut";
-import BiggerIcon from "../icons/Bigger";
-import SmallerIcon from "../icons/Smaller";
-import PaletteIcon from "../icons/Palette";
-import DeleteIcon from "../icons/Delete";
-import SaveIcon from "../icons/Save";
-import ImageIcon from "../icons/Image";
 import { FileSystemModule } from "../modules/file-system/FileSystemModule";
+import { hackTouchableNode } from "../utils/touchHandlerHack";
 
-const icons: Record<string, ReactElement> = {
-  draw: <PenIcon />,
-  pan: <HandIcon />,
-  move: <MoveIcon />,
-  zoomIn: <ZoomInIcon />,
-  zoomOut: <ZoomOutIcon />,
-  bigger: <BiggerIcon />,
-  smaller: <SmallerIcon />,
-  color: <PaletteIcon />,
-  erase: <DeleteIcon />,
-  save: <SaveIcon />,
-  image: <ImageIcon />,
-};
+const getIcons = (stateValue: any) => [
+  stateValue.selection === "selection"
+    ? {
+        id: "move",
+        component: MoveIcon,
+        eventType: "SELECT_MOVE",
+        active: stateValue.mode.pan,
+      }
+    : {
+        id: "pan",
+        PannerNode,
+        component: HandIcon,
+        eventType: "SELECT_PAN",
+        active: stateValue.mode.pan,
+      },
+  {
+    id: "draw",
+    component: PenIcon,
+    eventType: "SELECT_DRAW",
+    active: stateValue.mode.draw,
+  },
+  {
+    id: "erase",
+    component: DeleteIcon,
+    eventType: "SELECT_ERASE",
+    active: stateValue.mode.erase,
+  },
+  stateValue.selection === "noSelection"
+    ? {
+        id: "zoomIn",
+        component: ZoomInIcon,
+        eventType: "ZOOM_IN",
+      }
+    : {
+        id: "bigger",
+        component: BiggerIcon,
+        eventType: "BIGGER",
+      },
+  stateValue.selection === "noSelection"
+    ? {
+        id: "zoomOut",
+        component: ZoomOutIcon,
+        eventType: "ZOOM_OUT",
+      }
+    : {
+        id: "smaller",
+        component: SmallerIcon,
+        eventType: "SMALLER",
+      },
+
+  {
+    id: "color",
+    component: PaletteIcon,
+    eventType: "SELECT_COLOR",
+    active: stateValue.mode === "color",
+  },
+  { id: "save", component: SaveIcon, eventType: "SELECT_SAVE" },
+  { id: "image", component: ImageIcon, eventType: "UPLOAD_IMAGE" },
+];
 
 type Props = {
   size?: number;
   margin?: number;
   radius?: number;
-  ColorPickerElement?: ReactElement;
   fileSystemModule: FileSystemModule;
+  service: any;
 };
+
+const selectStateValue = (state: any) => state.value;
 
 export const Toolbar: FC<Props> = ({
   size = 36,
   margin = 8,
   radius = 6,
-  ColorPickerElement = <ColorPicker />,
   fileSystemModule,
+  service,
 }) => {
-  const [tools, dispatch] = useAtom(toolbarAtom);
+  const stateValue = useSelector(service, selectStateValue);
+  const icons = getIcons(stateValue);
   return (
     <>
       <Rect
@@ -57,45 +104,56 @@ export const Toolbar: FC<Props> = ({
         rx={radius}
         ry={radius}
         width={size + margin * 2}
-        height={margin + (size + margin) * tools.length}
+        height={margin + (size + margin) * icons.length}
         fill="#ddd"
         opacity="0.8"
       />
-      {tools.map((tool, i) => (
-        <G
-          key={tool.id}
-          onPress={() => {
-            dispatch({ id: tool.id, fileSystemModule });
-          }}
-          ref={hackTouchableNode}
-        >
-          <Rect
-            x={margin}
-            y={margin + (size + margin) * i}
-            rx={radius}
-            ry={radius}
-            width={size}
-            height={size}
-            stroke={tool.active ? "#000" : "none"}
-            strokeWidth="2.5"
-            fill="#aaa"
-            opacity="0.8"
-          />
+      {icons.map((tool, i) => {
+        const ToolComponent = tool.component;
+
+        return (
           <G
-            x={margin + (size - 24) / 2}
-            y={margin + (size + margin) * i + (size - 24) / 2}
-            fill="#444"
+            key={tool.id}
+            onPress={() => {
+              service.send(tool.eventType as any);
+            }}
+            ref={hackTouchableNode}
           >
-            {icons[tool.id]}
+            <Rect
+              x={margin}
+              y={margin + (size + margin) * i}
+              rx={radius}
+              ry={radius}
+              width={size}
+              height={size}
+              stroke={tool.active ? "#000" : "none"}
+              strokeWidth="2.5"
+              fill="#aaa"
+              opacity="0.8"
+            />
+            <G
+              x={margin + (size - 24) / 2}
+              y={margin + (size + margin) * i + (size - 24) / 2}
+              fill="#444"
+            >
+              <ToolComponent></ToolComponent>
+            </G>
           </G>
+        );
+      })}
+      {stateValue.mode === "color" && (
+        <G
+          id="colorpicker"
+          transform={`translate(${size + margin * 3} ${margin})`}
+        >
+          {/* FTODO: this was passed as props, but it never changes? I'm not making it a prop so I can add props to it myself */}
+          <ColorPicker
+            setColor={(color: string) =>
+              service.send({ type: "SET_COLOR", color })
+            }
+          />
         </G>
-      ))}
-      <G
-        id="colorpicker"
-        transform={`translate(${size + margin * 3} ${margin})`}
-      >
-        {ColorPickerElement}
-      </G>
+      )}
     </>
   );
 };

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -18,16 +18,15 @@ import { FileSystemModule } from "../modules/file-system/FileSystemModule";
 import { hackTouchableNode } from "../utils/touchHandlerHack";
 
 const getIcons = (stateValue: any) => [
-  stateValue.selection === "selection"
+  stateValue.selection === "shapeSelected"
     ? {
         id: "move",
         component: MoveIcon,
-        eventType: "SELECT_MOVE",
+        eventType: "SELECT_PAN",
         active: stateValue.mode.pan,
       }
     : {
         id: "pan",
-        PannerNode,
         component: HandIcon,
         eventType: "SELECT_PAN",
         active: stateValue.mode.pan,

--- a/src/machines/CanvasMachine.ts
+++ b/src/machines/CanvasMachine.ts
@@ -16,7 +16,6 @@ type CanvasEvent =
   | { type: "SELECT_COLOR" }
   | { type: "SELECT_PAN" }
   | { type: "SELECT_DRAW" }
-  | { type: "SELECT_MOVE" }
   | { type: "SELECT_ERASE" }
   | { type: "POINT_IS_IN_SHAPE"; id: string }
   | { type: "ZOOM_IN" }
@@ -235,9 +234,6 @@ const CanvasMachine = createMachine<CanvasContext, CanvasEvent>(
         on: {
           SELECT_DRAW: {
             target: "#canvas.mode.draw",
-          },
-          SELECT_MOVE: {
-            // target: "move",
           },
           SELECT_ERASE: {
             target: "#canvas.mode.erase",

--- a/src/machines/CanvasMachine.ts
+++ b/src/machines/CanvasMachine.ts
@@ -1,0 +1,625 @@
+import getPath from "perfect-freehand";
+import { assign, createMachine, spawn } from "xstate";
+import { pure, send } from "xstate/lib/actions";
+import { PrintCanvas } from "../components/PrintCanvas";
+import { FileSystem } from "../modules/file-system/FileSystem";
+import { serialize } from "../utils/serialize";
+import { adjustSvgPath } from "../utils/svgpath";
+import { v4 as uuid } from "uuid";
+import ImageMachine from "./ImageMachine";
+import ShapeMachine from "./ShapeMachine";
+
+type CanvasEvent =
+  | { type: "START_DRAG"; pos: [number, number] }
+  | { type: "END_DRAG" }
+  | { type: "DRAG"; pos: [number, number] }
+  | { type: "SELECT_COLOR" }
+  | { type: "SELECT_PAN" }
+  | { type: "SELECT_DRAW" }
+  | { type: "SELECT_MOVE" }
+  | { type: "SELECT_ERASE" }
+  | { type: "POINT_IS_IN_SHAPE"; id: string }
+  | { type: "ZOOM_IN" }
+  | { type: "ZOOM_OUT" }
+  | { type: "BIGGER" }
+  | { type: "SMALLER" }
+  | { type: "SHAPE_SELECTED"; id: string }
+  | { type: "SHAPE_DESELECTED"; id: string }
+  | { type: "DESELECT_SHAPE" }
+  | { type: "UPLOAD_IMAGE" }
+  | { type: "SELECT_SAVE" }
+  | { type: "SET_DIMENSIONS"; width: number; height: number }
+  | { type: "SET_COLOR"; color: string }
+  | { type: "SHAPE_UPDATED"; id: string; shapeData: any }
+  | { type: "REGISTER_IS_POINT_IN_SHAPE"; id: string; isPointInShape: any }
+  | { type: "done.invoke.fetchData" }
+  | { type: "done.invoke.imageUpload"; data: any };
+
+interface CanvasContext {
+  dimensions: { width: number; height: number };
+  offset: { x: number; y: number };
+  dragCurrentPosition: [number, number];
+  dragStartPosition: [number, number];
+  zoom: number;
+  dots: any;
+  shapes: any;
+  allShapesData: any;
+  selectedShapes: string[];
+  color: string;
+}
+
+type TShapeCommon = {
+  x: number;
+  y: number;
+  scale: number;
+  selected?: boolean;
+};
+
+export type TShapeImage = TShapeCommon & {
+  image: string;
+  width: number;
+  height: number;
+};
+
+const CanvasMachine = createMachine<CanvasContext, CanvasEvent>(
+  {
+    key: "canvas",
+    initial: "draw",
+    type: "parallel",
+    context: {
+      dimensions: { width: 0, height: 0 },
+      offset: { x: 0, y: 0 },
+      dragStartPosition: [0, 0],
+      dragCurrentPosition: [0, 0],
+      zoom: 1,
+      shapes: {},
+      allShapesData: {},
+      dots: [],
+      selectedShapes: [],
+      color: "black",
+    },
+    states: {
+      selection: {
+        initial: "noSelection",
+        states: {
+          noSelection: {
+            on: {
+              ZOOM_IN: {
+                actions: ["setOffsetFromZoomIn"],
+              },
+              ZOOM_OUT: {
+                actions: ["setOffsetFromZoomOut"],
+              },
+              SHAPE_SELECTED: {
+                target: "shapeSelected",
+                actions: ["addSelectedShape"],
+              },
+            },
+          },
+          shapeSelected: {
+            on: {
+              SHAPE_SELECTED: {
+                actions: ["addSelectedShape"],
+              },
+              SHAPE_DESELECTED: [
+                {
+                  target: "noSelection",
+                  actions: ["removeSelectedShape"],
+                  cond: "noShapesSelected",
+                },
+                {
+                  actions: ["removeSelectedShape"],
+                },
+              ],
+              SELECT_DRAW: {
+                target: "noSelection",
+                actions: ["clearSelectedShapes", "notifyShapesShouldDeselect"],
+              },
+              SELECT_ERASE: {
+                target: "noSelection",
+                actions: ["clearSelectedShapes", "notifyShapesShouldDeselect"],
+              },
+              SELECT_PAN: {
+                target: "noSelection",
+                actions: ["clearSelectedShapes", "notifyShapesShouldDeselect"],
+              },
+              BIGGER: {
+                actions: ["notifySelectedShapesBigger"],
+              },
+              SMALLER: {
+                actions: ["notifySelectedShapesSmaller"],
+              },
+            },
+          },
+        },
+      },
+      mode: {
+        initial: "draw",
+        states: {
+          draw: {
+            initial: "idle",
+            states: {
+              idle: {
+                on: {
+                  START_DRAG: {
+                    target: "dragging",
+                    actions: ["addDotPosition"],
+                  },
+                },
+              },
+              dragging: {
+                on: {
+                  DRAG: {
+                    actions: ["addDotPosition"],
+                  },
+                  END_DRAG: {
+                    target: "idle",
+                    actions: ["commitDots", "clearDots"],
+                  },
+                },
+              },
+            },
+          },
+          pan: {
+            initial: "idle",
+            states: {
+              idle: {
+                on: {
+                  START_DRAG: {
+                    target: "dragging",
+                    actions: ["setDragStartPosition", "setDragCurrentPosition"],
+                  },
+                },
+              },
+              dragging: {
+                on: {
+                  DRAG: [
+                    {
+                      in: "#canvas.selection.shapeSelected",
+                      actions: ["notifySelectedShapesMove"],
+                    },
+                    {
+                      actions: [
+                        "setOffsetWhilePanning",
+                        "setDragCurrentPosition",
+                      ],
+                    },
+                  ],
+                  END_DRAG: {
+                    target: "idle",
+                  },
+                },
+              },
+            },
+          },
+          erase: {
+            initial: "idle",
+            states: {
+              idle: {
+                on: {
+                  START_DRAG: {
+                    target: "dragging",
+                    actions: [],
+                  },
+                },
+              },
+              dragging: {
+                on: {
+                  DRAG: {
+                    actions: ["notifyShapesCheckPointInShape"],
+                  },
+                  END_DRAG: {
+                    target: "idle",
+                  },
+                },
+              },
+            },
+            on: {
+              POINT_IS_IN_SHAPE: {
+                actions: ["deleteShape"],
+              },
+            },
+          },
+          color: {
+            on: {
+              SET_COLOR: {
+                target: "draw",
+                actions: ["setColor", "notifySelectedShapesColor"],
+              },
+              SELECT_COLOR: {
+                target: "draw",
+              },
+            },
+          },
+        },
+        on: {
+          SELECT_DRAW: {
+            target: "#canvas.mode.draw",
+          },
+          SELECT_MOVE: {
+            // target: "move",
+          },
+          SELECT_ERASE: {
+            target: "#canvas.mode.erase",
+          },
+          SELECT_PAN: {
+            target: "#canvas.mode.pan",
+          },
+          SELECT_COLOR: [
+            {
+              target: "#canvas.mode.color",
+            },
+          ],
+          SELECT_SAVE: {
+            actions: [
+              (ctx) => {
+                const svgString = serialize(
+                  PrintCanvas({ shapes: Object.values(ctx.allShapesData) })
+                );
+                FileSystem.saveSvgFile(svgString);
+              },
+            ],
+          },
+        },
+      },
+      imageUpload: {
+        initial: "idle",
+        states: {
+          idle: {
+            on: {
+              UPLOAD_IMAGE: {
+                target: "selecting",
+              },
+            },
+          },
+          selecting: {
+            invoke: {
+              id: "imageUpload",
+              src: () => FileSystem.loadImageFile(),
+              onDone: {
+                target: "idle",
+                actions: ["addImage"],
+              },
+            },
+          },
+        },
+      },
+    },
+    on: {
+      SET_DIMENSIONS: {
+        actions: ["setDimensions"],
+      },
+      REGISTER_IS_POINT_IN_SHAPE: {
+        actions: ["registerIsPointInShape"],
+      },
+      SHAPE_UPDATED: {
+        actions: ["updateShapeData"],
+      },
+    },
+  },
+  {
+    actions: {
+      addDotPosition: assign({
+        dots: (ctx, event) => {
+          if (event.type !== "START_DRAG" && event.type !== "DRAG")
+            return ctx.dots;
+          const [x, y] = event.pos;
+          const { zoom, offset } = ctx;
+          return [...ctx.dots, [x / zoom + offset.x, y / zoom + offset.y]];
+        },
+      }),
+      commitDots: assign((ctx) => {
+        const id = uuid();
+        const path = getPath(ctx.dots);
+        const shapeData = {
+          ...adjustSvgPath(path),
+          scale: 1,
+          color: ctx.color,
+          id,
+        };
+        const shape = {
+          ref: spawn(
+            ShapeMachine.withContext({
+              ...shapeData,
+              isPointInShape: undefined,
+            })
+          ),
+          type: "path",
+          id,
+        };
+        return {
+          ...ctx,
+          shapes: { ...ctx.shapes, [id]: shape },
+          allShapesData: { ...ctx.allShapesData, [id]: shapeData },
+        };
+      }),
+      clearDots: assign({
+        dots: (ctx) => [],
+      }),
+      addImage: assign((ctx, event) => {
+        if (event.type !== "done.invoke.imageUpload") return ctx;
+        const id = uuid();
+        const shapeData = {
+          x: 100,
+          y: 100,
+          scale: 1,
+          image: event.data,
+          width: 300,
+          height: 300,
+          id,
+        };
+        const shape = {
+          ref: spawn(ImageMachine.withContext(shapeData)),
+          type: "image",
+          id,
+        };
+        return {
+          ...ctx,
+          shapes: { ...ctx.shapes, [id]: shape },
+          allShapesData: { ...ctx.allShapesData, [id]: shapeData },
+        };
+      }),
+      setColor: assign({
+        color: (ctx, event) => {
+          if (event.type !== "SET_COLOR") return ctx.color;
+          return event.color;
+        },
+      }),
+      setDragStartPosition: assign({
+        dragStartPosition: (ctx, event) => {
+          if (event.type !== "START_DRAG") return ctx.dragStartPosition;
+          return [
+            ctx.offset.x + event.pos[0] / ctx.zoom,
+            ctx.offset.y + event.pos[1] / ctx.zoom,
+          ];
+        },
+      }),
+      setOffsetWhilePanning: assign({
+        offset: (ctx, event) => {
+          if (event.type !== "DRAG") return ctx.offset;
+          let deltaX = event.pos[0] - ctx.dragCurrentPosition[0];
+          let deltaY = event.pos[1] - ctx.dragCurrentPosition[1];
+          return {
+            x: ctx.offset.x - deltaX / ctx.zoom,
+            y: ctx.offset.y - deltaY / ctx.zoom,
+          };
+        },
+      }),
+      setOffsetFromZoomIn: assign((ctx, event) => {
+        if (event.type !== "ZOOM_IN") return ctx;
+        const nextZoom = ctx.zoom * 1.2;
+        const nextoffset = {
+          x:
+            ctx.offset.x +
+            (ctx.dimensions.width * (1 / ctx.zoom - 1 / nextZoom)) / 2,
+          y:
+            ctx.offset.y +
+            (ctx.dimensions.height * (1 / ctx.zoom - 1 / nextZoom)) / 2,
+        };
+        return {
+          ...ctx,
+          zoom: nextZoom,
+          offset: nextoffset,
+        };
+      }),
+      setOffsetFromZoomOut: assign((ctx, event) => {
+        if (event.type !== "ZOOM_OUT") return ctx;
+        const nextZoom = ctx.zoom / 1.2;
+        const nextoffset = {
+          x:
+            ctx.offset.x +
+            (ctx.dimensions.width * (1 / ctx.zoom - 1 / nextZoom)) / 2,
+          y:
+            ctx.offset.y +
+            (ctx.dimensions.height * (1 / ctx.zoom - 1 / nextZoom)) / 2,
+        };
+        return {
+          ...ctx,
+          zoom: nextZoom,
+          offset: nextoffset,
+        };
+      }),
+      setDimensions: assign({
+        dimensions: (ctx, event) => {
+          if (event.type !== "SET_DIMENSIONS") return ctx.dimensions;
+          return {
+            width: event.width,
+            height: event.height,
+          };
+        },
+      }),
+      addSelectedShape: assign({
+        selectedShapes: (ctx, event) => {
+          if (event.type !== "SHAPE_SELECTED") return ctx.selectedShapes;
+          return [...ctx.selectedShapes, event.id];
+        },
+      }),
+      removeSelectedShape: assign({
+        selectedShapes: (ctx, event) => {
+          if (event.type !== "SHAPE_DESELECTED") return ctx.selectedShapes;
+          return ctx.selectedShapes.filter((id) => id !== event.id);
+        },
+      }),
+      clearSelectedShapes: assign({
+        selectedShapes: (ctx) => [],
+      }),
+      registerIsPointInShape: assign({
+        shapes: (ctx, event) => {
+          if (event.type !== "REGISTER_IS_POINT_IN_SHAPE") return ctx.shapes;
+          let updatedShapes = {
+            ...ctx.shapes,
+            [event.id]: {
+              ...ctx.shapes[event.id],
+              isPointInShape: event.isPointInShape,
+            },
+          };
+
+          return updatedShapes;
+        },
+      }),
+      checkShapeInDrag: pure((ctx, event) => {
+        if (event.type !== "DRAG") return [] as any;
+        const ids: string[] = [];
+        Object.keys(ctx.shapes).forEach((id: any) => {
+          if (
+            ctx.shapes[id].isPointInShape?.(event.pos, ctx.offset, ctx.zoom)
+          ) {
+            ids.push(id);
+          }
+        });
+        if (ids.length > 0) {
+          let newShapes = { ...ctx.shapes };
+          ids.forEach((id) => {
+            delete newShapes[id];
+          });
+          return [
+            assign({
+              shapes: newShapes,
+            }),
+          ];
+        }
+        return [];
+      }),
+      notifyShapesShouldDeselect: pure((ctx) => {
+        return Object.values(ctx.shapes).map((shape: any) => {
+          return send({ type: "DESELECT_SHAPE" }, { to: shape.ref });
+        });
+      }),
+      notifyShapesCheckPointInShape: pure((ctx, event) => {
+        if (event.type !== "DRAG") return [] as any;
+        return Object.values(ctx.shapes).map((shape: any) => {
+          return send(
+            {
+              type: "CHECK_POINT_IN_SHAPE",
+              pos: event.pos,
+              offset: ctx.offset,
+              zoom: ctx.zoom,
+            },
+            { to: shape.ref }
+          );
+        });
+      }),
+      notifySelectedShapesColor: pure((ctx, event) => {
+        if (event.type !== "SET_COLOR") return [] as any;
+        return ctx.selectedShapes.map((id) => {
+          const shape = ctx.shapes[id];
+          return send(
+            {
+              type: "SET_COLOR",
+              color: event.color,
+            },
+            { to: shape.ref }
+          );
+        });
+      }),
+      notifySelectedShapesBigger: pure((ctx, event) => {
+        if (event.type !== "BIGGER") return [] as any;
+        let left = Infinity;
+        let top = Infinity;
+        ctx.selectedShapes.forEach((id) => {
+          const shapeData = ctx.allShapesData[id];
+          left = Math.min(left, shapeData.x);
+          top = Math.min(top, shapeData.y);
+        });
+        return ctx.selectedShapes.map((id) => {
+          const shape = ctx.shapes[id];
+          return send(
+            {
+              type: "BIGGER",
+              left,
+              top,
+            },
+            { to: shape.ref }
+          );
+        });
+      }),
+      notifySelectedShapesSmaller: pure((ctx, event) => {
+        if (event.type !== "SMALLER") return [] as any;
+        let left = Infinity;
+        let top = Infinity;
+        ctx.selectedShapes.forEach((id) => {
+          const shapeData = ctx.allShapesData[id];
+          left = Math.min(left, shapeData.x);
+          top = Math.min(top, shapeData.y);
+        });
+        return ctx.selectedShapes.map((id) => {
+          const shape = ctx.shapes[id];
+          return send(
+            {
+              type: "SMALLER",
+              left,
+              top,
+            },
+            { to: shape.ref }
+          );
+        });
+      }),
+      notifySelectedShapesMove: pure((ctx, event) => {
+        if (event.type !== "DRAG") return [] as any;
+        let deltaX = (event.pos[0] - ctx.dragCurrentPosition[0]) / ctx.zoom;
+        let deltaY = (event.pos[1] - ctx.dragCurrentPosition[1]) / ctx.zoom;
+        const allShapesData = { ...ctx.allShapesData };
+        ctx.selectedShapes.forEach((id) => {
+          const shapeData = ctx.allShapesData[id];
+          const newX = shapeData.x + deltaX;
+          const newY = shapeData.y + deltaY;
+          allShapesData[id] = { ...shapeData, x: newX, y: newY };
+        });
+
+        const actions: any = ctx.selectedShapes.map((id) => {
+          const shape = ctx.shapes[id];
+          return send(
+            {
+              type: "MOVE",
+              deltaX,
+              deltaY,
+            },
+            { to: shape.ref }
+          );
+        });
+        actions.push(assign({ allShapesData }));
+
+        // this is included here rather than in the event definition because in v4
+        // assign actions have priority, but we need to get the prev drag position before overwriting it
+        actions.push("setDragCurrentPosition");
+
+        return actions;
+      }),
+      deleteShape: assign((ctx, event) => {
+        if (event.type !== "POINT_IS_IN_SHAPE") return ctx;
+        let newShapes = { ...ctx.shapes };
+        delete newShapes[event.id];
+        let newAllShapesData = { ...ctx.allShapesData };
+        delete newAllShapesData[event.id];
+        return {
+          ...ctx,
+          shapes: newShapes,
+          allShapesData: newAllShapesData,
+        };
+      }),
+      updateShapeData: assign({
+        allShapesData: (ctx, event) => {
+          if (event.type !== "SHAPE_UPDATED") return ctx.shapes;
+          return { ...ctx.allShapesData, [event.id]: event.shapeData };
+        },
+      }),
+      setDragCurrentPosition: assign({
+        dragCurrentPosition: (ctx, event) => {
+          if (event.type !== "START_DRAG" && event.type !== "DRAG")
+            return ctx.dragCurrentPosition;
+          return event.pos;
+        },
+      }),
+    },
+    guards: {
+      noShapesSelected: (ctx, event) => {
+        if (event.type !== "SHAPE_DESELECTED") return false;
+        return (
+          ctx.selectedShapes.length === 1 && ctx.selectedShapes[0] === event.id
+        );
+      },
+    },
+  }
+);
+
+export default CanvasMachine;

--- a/src/machines/ImageMachine.ts
+++ b/src/machines/ImageMachine.ts
@@ -1,0 +1,136 @@
+import { assign, createMachine } from "xstate";
+import { pure, sendParent } from "xstate/lib/actions";
+
+type ShapeEvent =
+  | { type: "BIGGER"; top: number; left: number }
+  | { type: "SMALLER"; top: number; left: number }
+  | { type: "SELECT_SHAPE" }
+  | { type: "DESELECT_SHAPE" }
+  | { type: "REGISTER_IS_POINT_IN_SHAPE"; isPointInShape: any }
+  | { type: "MOVE"; deltaX: number; deltaY: number };
+
+interface ImageContext {
+  x: number;
+  y: number;
+  scale: number;
+  id: string;
+  image: string;
+  width: number;
+  height: number;
+}
+
+type TShapeCommon = {
+  x: number;
+  y: number;
+  scale: number;
+  selected?: boolean;
+};
+
+export type TShapeImage = TShapeCommon & {
+  image: string;
+  width: number;
+  height: number;
+};
+
+const ImageMachine = createMachine<ImageContext, ShapeEvent>(
+  {
+    key: "shape",
+    initial: "unselected",
+    context: {
+      x: 0,
+      y: 0,
+      scale: 1,
+      id: "",
+      image: "",
+      width: 0,
+      height: 0,
+    },
+    states: {
+      unselected: {
+        on: {
+          SELECT_SHAPE: {
+            target: "selected",
+            actions: ["notifyParentShapeSelected"],
+          },
+        },
+      },
+      selected: {
+        on: {
+          DESELECT_SHAPE: {
+            target: "unselected",
+            actions: ["notifyParentShapeDeselected"],
+          },
+        },
+      },
+    },
+    on: {
+      BIGGER: {
+        actions: ["makeShapeBigger", "notifyParentShapeUpdated"],
+      },
+      SMALLER: {
+        actions: ["makeShapeSmaller", "notifyParentShapeUpdated"],
+      },
+      MOVE: {
+        actions: ["movePosition"],
+      },
+    },
+  },
+  {
+    actions: {
+      notifyParentShapeSelected: sendParent((ctx) => ({
+        type: "SHAPE_SELECTED",
+        id: ctx.id,
+      })),
+      notifyParentShapeDeselected: sendParent((ctx) => ({
+        type: "SHAPE_DESELECTED",
+        id: ctx.id,
+      })),
+      makeShapeBigger: assign((ctx, event) => {
+        if (event.type !== "BIGGER") return ctx;
+        const { x, y, scale } = ctx;
+        const { top, left } = event;
+        const nextScale = scale * 1.2;
+        return {
+          ...ctx,
+          x: left + (x - left) * (nextScale / scale),
+          y: top + (y - top) * (nextScale / scale),
+          scale: nextScale,
+        };
+      }),
+      makeShapeSmaller: assign((ctx, event) => {
+        if (event.type !== "SMALLER") return ctx;
+        const { x, y, scale } = ctx;
+        const { top, left } = event;
+        const nextScale = scale / 1.2;
+        return {
+          ...ctx,
+          x: left + (x - left) * (nextScale / scale),
+          y: top + (y - top) * (nextScale / scale),
+          scale: nextScale,
+        };
+      }),
+      notifyParentShapeUpdated: sendParent((ctx) => ({
+        type: "SHAPE_UPDATED",
+        id: ctx.id,
+        shapeData: {
+          x: 0,
+          y: ctx.y,
+          image: ctx.image,
+          width: ctx.width,
+          height: ctx.height,
+          scale: ctx.scale,
+          id: ctx.id,
+        },
+      })),
+      movePosition: assign((ctx, event) => {
+        if (event.type !== "MOVE") return ctx;
+        console.log("MOVE", event);
+        const newX = ctx.x + event.deltaX;
+        const newY = ctx.y + event.deltaY;
+        return { ...ctx, x: newX, y: newY };
+      }),
+    },
+  }
+);
+
+export default ImageMachine;

--- a/src/machines/ImageMachine.ts
+++ b/src/machines/ImageMachine.ts
@@ -1,5 +1,5 @@
 import { assign, createMachine } from "xstate";
-import { pure, sendParent } from "xstate/lib/actions";
+import { sendParent } from "xstate/lib/actions";
 
 type ShapeEvent =
   | { type: "BIGGER"; top: number; left: number }

--- a/src/machines/ShapeMachine.ts
+++ b/src/machines/ShapeMachine.ts
@@ -1,0 +1,170 @@
+import { assign, createMachine } from "xstate";
+import { pure, sendParent } from "xstate/lib/actions";
+
+type ShapeEvent =
+  | { type: "BIGGER"; top: number; left: number }
+  | { type: "SMALLER"; top: number; left: number }
+  | { type: "SELECT_SHAPE" }
+  | { type: "DESELECT_SHAPE" }
+  | { type: "SET_COLOR"; color: string }
+  | { type: "REGISTER_IS_POINT_IN_SHAPE"; isPointInShape: any }
+  | { type: "MOVE"; deltaX: number; deltaY: number }
+  | {
+      type: "CHECK_POINT_IN_SHAPE";
+      zoom: number;
+      offset: number;
+      pos: [number, number];
+    };
+
+interface ShapeContext {
+  x: number;
+  y: number;
+  path: string;
+  scale: number;
+  color: string;
+  id: string;
+  isPointInShape: any;
+}
+
+type TShapeCommon = {
+  x: number;
+  y: number;
+  scale: number;
+  selected?: boolean;
+};
+
+export type TShapeImage = TShapeCommon & {
+  image: string;
+  width: number;
+  height: number;
+};
+
+const ShapeMachine = createMachine<ShapeContext, ShapeEvent>(
+  {
+    key: "shape",
+    initial: "unselected",
+    context: {
+      x: 0,
+      y: 0,
+      path: "",
+      scale: 1,
+      color: "black",
+      id: "",
+      isPointInShape: undefined,
+    },
+    states: {
+      unselected: {
+        on: {
+          SELECT_SHAPE: {
+            target: "selected",
+            actions: ["notifyParentShapeSelected"],
+          },
+        },
+      },
+      selected: {
+        on: {
+          DESELECT_SHAPE: {
+            target: "unselected",
+            actions: ["notifyParentShapeDeselected"],
+          },
+        },
+      },
+    },
+    on: {
+      REGISTER_IS_POINT_IN_SHAPE: {
+        actions: ["registerIsPointInShape"],
+      },
+      CHECK_POINT_IN_SHAPE: {
+        actions: ["checkIsPointInShape"],
+      },
+      SET_COLOR: {
+        actions: ["assignColor", "notifyParentShapeUpdated"],
+      },
+      BIGGER: {
+        actions: ["makeShapeBigger", "notifyParentShapeUpdated"],
+      },
+      SMALLER: {
+        actions: ["makeShapeSmaller", "notifyParentShapeUpdated"],
+      },
+      MOVE: {
+        actions: ["movePosition"],
+      },
+    },
+  },
+  {
+    actions: {
+      notifyParentShapeSelected: sendParent((ctx) => ({
+        type: "SHAPE_SELECTED",
+        id: ctx.id,
+      })),
+      notifyParentShapeDeselected: sendParent((ctx) => ({
+        type: "SHAPE_DESELECTED",
+        id: ctx.id,
+      })),
+      makeShapeBigger: assign((ctx, event) => {
+        if (event.type !== "BIGGER") return ctx;
+        const { x, y, scale } = ctx;
+        const { top, left } = event;
+        const nextScale = scale * 1.2;
+        return {
+          ...ctx,
+          x: left + (x - left) * (nextScale / scale),
+          y: top + (y - top) * (nextScale / scale),
+          scale: nextScale,
+        };
+      }),
+      makeShapeSmaller: assign((ctx, event) => {
+        if (event.type !== "SMALLER") return ctx;
+        const { x, y, scale } = ctx;
+        const { top, left } = event;
+        const nextScale = scale / 1.2;
+        return {
+          ...ctx,
+          x: left + (x - left) * (nextScale / scale),
+          y: top + (y - top) * (nextScale / scale),
+          scale: nextScale,
+        };
+      }),
+      registerIsPointInShape: assign({
+        isPointInShape: (ctx, event) => {
+          if (event.type !== "REGISTER_IS_POINT_IN_SHAPE")
+            return ctx.isPointInShape;
+          return event.isPointInShape;
+        },
+      }),
+      checkIsPointInShape: pure((ctx, event) => {
+        if (event.type !== "CHECK_POINT_IN_SHAPE") return [] as any;
+        const { pos, offset, zoom } = event;
+        if (ctx.isPointInShape?.(pos, offset, zoom)) {
+          return sendParent({ type: "POINT_IS_IN_SHAPE", id: ctx.id });
+        }
+      }),
+      assignColor: assign({
+        color: (ctx, event) => {
+          if (event.type !== "SET_COLOR") return ctx.color;
+          return event.color;
+        },
+      }),
+      notifyParentShapeUpdated: sendParent((ctx) => ({
+        type: "SHAPE_UPDATED",
+        id: ctx.id,
+        shapeData: {
+          x: ctx.x,
+          y: ctx.y,
+          path: ctx.path,
+          scale: ctx.scale,
+          color: ctx.color,
+          id: ctx.id,
+        },
+      })),
+      movePosition: assign((ctx, event) => {
+        if (event.type !== "MOVE") return ctx;
+        const newX = ctx.x + event.deltaX;
+        const newY = ctx.y + event.deltaY;
+        return { ...ctx, x: newX, y: newY };
+      }),
+    },
+  }
+);
+
+export default ShapeMachine;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/webpack-sources@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
@@ -2872,6 +2877,21 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xstate/inspect@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@xstate/inspect/-/inspect-0.4.1.tgz#6b00b945c03280a333de8ddf10e91830c361052d"
+  integrity sha512-tcGBUCVymP8ij0K2fXZckrwrQkmNJL1DgQAM0eSILQKb8iBDN3GeqhYkNCS4HP29EzF2TZL0+k74FPWKaU9Fhw==
+  dependencies:
+    fast-safe-stringify "^2.0.7"
+
+"@xstate/react@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.1.tgz#5794e1c7d2bc70759b5dc2c9ccc9ddaa6e68e98a"
+  integrity sha512-wgAHr4tWVQQwH6dIQTcZQYGLXiK9V8gMqMxOWyiLQzoKchqXFfb0LlCcw0FAc4jmpuGHSFSk6fAXjEpFpV+Jxw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -6303,6 +6323,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
 fastq@^1.6.0:
   version "1.10.1"
@@ -13689,7 +13714,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-subscription@^1.0.0:
+use-isomorphic-layout-effect@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
+  integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
+
+use-subscription@^1.0.0, use-subscription@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
   integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
@@ -13770,7 +13800,7 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -14429,6 +14459,11 @@ xpipe@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
   integrity sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98=
+
+xstate@^4.16.2:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.2.tgz#d6b973b1253b8c85f50f68601837287d59d4bf34"
+  integrity sha512-EY39NNZnwM4tRYNmQAi1c2qHuZ1lJmuDpEo1jxiRcfS+1jPtKRAjGRLNx3fYKcK0ohW6mL41Wze3mdCF0SqavA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,9 +2886,9 @@
     fast-safe-stringify "^2.0.7"
 
 "@xstate/react@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.1.tgz#5794e1c7d2bc70759b5dc2c9ccc9ddaa6e68e98a"
-  integrity sha512-wgAHr4tWVQQwH6dIQTcZQYGLXiK9V8gMqMxOWyiLQzoKchqXFfb0LlCcw0FAc4jmpuGHSFSk6fAXjEpFpV+Jxw==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.2.tgz#1fd7a7e26565a1d18193413c327a06d2038c8a51"
+  integrity sha512-wobnkgt3ewhzb7McW8kxMXmup/MeSyHOhgWryy0RU7x+q/m1RAS8GMjGn3YTPf2XI17AzB98a131zNdOe1lwIA==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
     use-subscription "^1.3.0"
@@ -14461,9 +14461,9 @@ xpipe@^1.0.5:
   integrity sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98=
 
 xstate@^4.16.2:
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.2.tgz#d6b973b1253b8c85f50f68601837287d59d4bf34"
-  integrity sha512-EY39NNZnwM4tRYNmQAi1c2qHuZ1lJmuDpEo1jxiRcfS+1jPtKRAjGRLNx3fYKcK0ohW6mL41Wze3mdCF0SqavA==
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.18.0.tgz#64a0002cc7deca1cb1891f002bbe786193e97497"
+  integrity sha512-cjj22XXxTWIkMrghyoUWjUlDFcd7MQGeKYy8bkdtcIeogZjF98mep9CHv8xLO3j4PZQF5qgcAGGT8FUn99mF1Q==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR uses XState to replace Jotai as the state manager for Katachidraw. 

**Purpose**
The aim is to replicate the existing functionality as closely as possible, so that this could be merged if desired. Otherwise, this code could serve as a reference for an alternative XState implementation, or even just as a comparison with the jotai implementation which is interesting in itself.

**To do:**
- History is not implemented yet. It is possible with XState, but it's a tricky feature to get right.
- Typings are not fully completed (I'm new to Typescript, so any help with these is welcome)
- Image rotation is not added yet.
- Code is duplicated between ShapeMachine and ImageMachine. I am still learning the best approach when there is shared code between machines.
- I didn't use jotai/xstate because I'm not familiar with it. At this stage I don't see what jotai/xstate would add compared to using xstate/react, which comes with the selectors and inspector already. However, it would hopefully be easy to swap one out for the other.


